### PR TITLE
Polish popup HUD layout responsiveness

### DIFF
--- a/src/components/CookieBackupManager.tsx
+++ b/src/components/CookieBackupManager.tsx
@@ -302,150 +302,148 @@ const CookieBackupManager: React.FC = () => {
   };
 
   return (
-    <div className="min-h-full bg-gray-900 text-gray-100">
-      {/* Header */}
-      <div className="bg-gray-800 border-b border-gray-700 p-4">
-        <h2 className="text-lg font-semibold mb-2" style={{color: '#15FFFF'}}>Cookie Backup & Restore</h2>
-        <p className="text-sm text-gray-400">One-click encrypted system-wide backup/restore</p>
-      </div>
+    <div className="hud-scroll space-y-4">
+      <section className="hud-section">
+        <div className="hud-section-header">
+          <div>
+            <h2 className="hud-section-title">Cookie backup &amp; restore</h2>
+            <p className="hud-section-subtitle">One-click encrypted system-wide backup/restore</p>
+          </div>
+          <span className="hud-chip">
+            <span className="hud-chip__dot" />
+            AES-256 GCM
+          </span>
+        </div>
+      </section>
 
-      <div className="p-4 space-y-6">
-        {/* Backup Section */}
-        <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-          <h3 className="text-md font-medium text-cyan-400 mb-4">System-wide Backup</h3>
-          
-          <div className="space-y-3">
-            <div className="relative">
+      <section className="hud-section">
+        <h3 className="hud-section-title">System-wide backup</h3>
+        <p className="hud-subtext">Creates an encrypted .4nt file with all cookies from all domains.</p>
+
+        <div className="hud-field-vertical">
+          <span className="hud-label">Backup password</span>
+          <div className="hud-field-row">
+            <div className="hud-input-wrapper">
               <input
                 type={showBackupPassword ? 'text' : 'password'}
                 value={backupPassword}
                 onChange={(e) => setBackupPassword(e.target.value)}
                 placeholder="Enter backup password"
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded focus:outline-none focus:border-cyan-400 pr-10"
+                className="hud-input"
               />
               <button
                 type="button"
                 onClick={() => setShowBackupPassword(!showBackupPassword)}
-                className="absolute right-3 top-2 text-gray-400 hover:text-cyan-400"
+                className="hud-input-toggle"
+                aria-label={showBackupPassword ? 'Hide password' : 'Show password'}
               >
                 {showBackupPassword ? '👁️' : '👁️‍🗨️'}
               </button>
             </div>
-            
             <button
+              type="button"
               onClick={backupAllCookies}
               disabled={isBackingUp || !backupPassword.trim()}
-              className={`w-full py-3 px-4 rounded font-medium transition-colors ${
-                isBackingUp || !backupPassword.trim()
-                  ? 'bg-gray-600 text-gray-400 cursor-not-allowed'
-                  : 'hover:opacity-80'
-              }`}
-              style={!isBackingUp && backupPassword.trim() ? {backgroundColor: '#15FFFF', color: '#111827'} : {}}
+              className="hud-btn"
+              data-variant="accent"
+              data-size="sm"
+              data-block="true"
             >
-              {isBackingUp ? '🔄 Creating Backup...' : '💾 One-Click Backup'}
+              {isBackingUp ? '🔄 Creating backup…' : '💾 One-click backup'}
             </button>
           </div>
-          
-          <p className="text-xs text-gray-500 mt-2">
-            Creates an encrypted .4nt file with all cookies from all domains
-          </p>
         </div>
+      </section>
 
-        {/* Restore Section */}
-        <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-          <h3 className="text-md font-medium text-cyan-400 mb-4">Restore from Backup</h3>
-          
-          <div className="space-y-3">
-            <input
-              type="file"
-              accept=".4nt"
-              onChange={handleFileSelect}
-              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded focus:outline-none focus:border-cyan-400 file:mr-4 file:py-1 file:px-2 file:rounded file:border-0 file:bg-cyan-400 file:text-gray-900 file:font-medium hover:file:bg-cyan-300"
-            />
-            
-            {restoreFile && (
-              <>
-                <div className="relative">
-                  <input
-                    type={showRestorePassword ? 'text' : 'password'}
-                    value={restorePassword}
-                    onChange={(e) => setRestorePassword(e.target.value)}
-                    placeholder="Enter restore password"
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded focus:outline-none focus:border-cyan-400 pr-10"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowRestorePassword(!showRestorePassword)}
-                    className="absolute right-3 top-2 text-gray-400 hover:text-cyan-400"
-                  >
-                    {showRestorePassword ? '👁️' : '👁️‍🗨️'}
-                  </button>
-                </div>
-                
-                <button
-                  onClick={restoreFromBackup}
-                  disabled={isRestoring || !restorePassword.trim()}
-                  className={`w-full py-3 px-4 rounded font-medium transition-colors ${
-                    isRestoring || !restorePassword.trim()
-                      ? 'bg-gray-600 text-gray-400 cursor-not-allowed'
-                      : 'bg-green-600 text-white hover:bg-green-500'
-                  }`}
-                >
-                  {isRestoring ? '🔄 Restoring...' : '📥 One-Click Restore'}
-                </button>
-              </>
-            )}
-          </div>
-          
-          {isRestoring && restoreTotal > 0 && (
-            <div className="mt-4">
-              <div className="flex justify-between text-sm text-gray-400 mb-1">
-                <span>Restoring cookies...</span>
-                <span>{restoreProgress} / {restoreTotal}</span>
-              </div>
-              <div className="w-full bg-gray-700 rounded-full h-2">
-                <div 
-                  className="bg-cyan-400 h-2 rounded-full transition-all duration-300"
-                  style={{ width: `${(restoreProgress / restoreTotal) * 100}%` }}
+      <section className="hud-section">
+        <h3 className="hud-section-title">Restore from backup</h3>
+        <p className="hud-subtext">Restores encrypted .4nt backup files and skips expired cookies automatically.</p>
+
+        <div className="hud-field-vertical">
+          <span className="hud-label">Encrypted backup file</span>
+          <input
+            type="file"
+            accept=".4nt"
+            onChange={handleFileSelect}
+            className="hud-file-input"
+          />
+
+          {restoreFile && (
+            <div className="hud-field-vertical">
+              <span className="hud-label">Restore password</span>
+              <div className="hud-input-wrapper">
+                <input
+                  type={showRestorePassword ? 'text' : 'password'}
+                  value={restorePassword}
+                  onChange={(e) => setRestorePassword(e.target.value)}
+                  placeholder="Enter restore password"
+                  className="hud-input"
                 />
+                <button
+                  type="button"
+                  onClick={() => setShowRestorePassword(!showRestorePassword)}
+                  className="hud-input-toggle"
+                  aria-label={showRestorePassword ? 'Hide password' : 'Show password'}
+                >
+                  {showRestorePassword ? '👁️' : '👁️‍🗨️'}
+                </button>
               </div>
+
+              <button
+                type="button"
+                onClick={restoreFromBackup}
+                disabled={isRestoring || !restorePassword.trim()}
+                className="hud-btn"
+                data-variant="success"
+                data-size="sm"
+                data-block="true"
+              >
+                {isRestoring ? '🔄 Restoring…' : '📥 One-click restore'}
+              </button>
             </div>
           )}
-          
-          <p className="text-xs text-gray-500 mt-2">
-            Restores encrypted .4nt backup files. Skips expired cookies automatically.
-          </p>
         </div>
 
-        {/* Last Backup Info */}
-        {lastBackup && (
-          <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-            <h3 className="text-md font-medium text-cyan-400 mb-3">Last Backup</h3>
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <div className="text-gray-400">Date:</div>
-              <div className="text-cyan-400 font-mono">
-                {new Date(lastBackup.timestamp).toLocaleString()}
-              </div>
-              <div className="text-gray-400">Cookies:</div>
-              <div className="text-cyan-400 font-mono">{lastBackup.totalCookies.toLocaleString()}</div>
-              <div className="text-gray-400">Encrypted:</div>
-              <div className="text-cyan-400">{lastBackup.encrypted ? '✓ Yes' : '✗ No'}</div>
+        {isRestoring && restoreTotal > 0 && (
+          <div className="hud-progress">
+            <div className="hud-progress__header">
+              <span>Restoring cookies…</span>
+              <span>{restoreProgress} / {restoreTotal}</span>
+            </div>
+            <div className="hud-progress__track">
+              <div
+                className="hud-progress__bar"
+                style={{ width: `${(restoreProgress / restoreTotal) * 100}%` }}
+              />
             </div>
           </div>
         )}
+      </section>
 
-        {/* Security Info */}
-        <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-          <h3 className="text-md font-medium text-cyan-400 mb-2">Security Features</h3>
-          <ul className="text-sm text-gray-400 space-y-1">
-            <li>• AES-256-GCM encryption with Web Crypto API</li>
-            <li>• PBKDF2 key derivation (100,000 iterations)</li>
-            <li>• Random salt and IV for each backup</li>
-            <li>• Custom .4nt file format</li>
-            <li>• No password storage or transmission</li>
-          </ul>
-        </div>
-      </div>
+      {lastBackup && (
+        <section className="hud-section">
+          <h3 className="hud-section-title">Last backup</h3>
+          <div className="hud-stat-grid">
+            <span className="hud-subtext">Date</span>
+            <span className="hud-subtext hud-subtext--mono">{new Date(lastBackup.timestamp).toLocaleString()}</span>
+            <span className="hud-subtext">Cookies</span>
+            <span className="hud-subtext hud-subtext--mono">{lastBackup.totalCookies.toLocaleString()}</span>
+            <span className="hud-subtext">Encrypted</span>
+            <span className="hud-subtext">{lastBackup.encrypted ? '✓ Yes' : '✗ No'}</span>
+          </div>
+        </section>
+      )}
+
+      <section className="hud-section hud-section--inline">
+        <h3 className="hud-section-title">Security features</h3>
+        <ul className="hud-list">
+          <li>AES-256-GCM encryption with Web Crypto API</li>
+          <li>PBKDF2 key derivation (100,000 iterations)</li>
+          <li>Random salt and IV per backup</li>
+          <li>Custom .4nt file format</li>
+          <li>No password storage or transmission</li>
+        </ul>
+      </section>
     </div>
   );
 };

--- a/src/components/CookieManager.tsx
+++ b/src/components/CookieManager.tsx
@@ -112,85 +112,104 @@ const CookieManager: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+      <div className="hud-loading">
+        <span className="hud-loading__spinner" aria-hidden="true" />
+        <p>Scanning cookies…</p>
       </div>
     );
   }
 
   return (
-    <div className="min-h-full bg-gray-900 text-gray-100">
-      {/* Header */}
-      <div className="bg-gray-800 border-b border-gray-700 p-4">
-        <h2 className="text-lg font-semibold mb-2" style={{color: '#15FFFF'}}>Cookie Tools</h2>
-        <p className="text-sm text-gray-400">One-click export to clipboard (JSON/Netscape)</p>
-      </div>
+    <div className="hud-scroll space-y-4">
+      <section className="hud-section">
+        <div className="hud-section-header">
+          <div>
+            <h2 className="hud-section-title">Cookie tools</h2>
+            <p className="hud-section-subtitle">One-click export to clipboard (JSON or Netscape)</p>
+          </div>
+          <span className="hud-chip">
+            <span className="hud-chip__dot" />
+            {filteredCookies.length} cookie{filteredCookies.length === 1 ? '' : 's'}
+          </span>
+        </div>
 
-      <div className="p-4">
-        <div className="mb-4">
-          <div className="flex space-x-2 mb-3">
+        <div className="hud-field-vertical">
+          <span className="hud-label">Search & export</span>
+          <div className="hud-field-row">
             <input
               type="text"
-              placeholder="Search cookies..."
+              placeholder="Search cookies…"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="flex-1 px-3 py-2 border border-gray-600 bg-gray-700 text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-cyan-400"
+              className="hud-input"
             />
             <button
+              type="button"
               onClick={() => exportToClipboard('json')}
-              className="px-4 py-2 rounded-md font-medium transition-colors hover:opacity-80"
-              style={{backgroundColor: '#15FFFF', color: '#111827'}}
+              className="hud-btn"
+              data-variant="accent"
+              data-size="sm"
             >
               📋 Copy JSON
             </button>
             <button
+              type="button"
               onClick={() => exportToClipboard('netscape')}
-              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-500 transition-colors font-medium"
+              className="hud-btn"
+              data-variant="success"
+              data-size="sm"
             >
               📋 Copy Netscape
             </button>
           </div>
-          
-          <div className="text-xs text-gray-500 mb-3">
-            Found {filteredCookies.length} cookie{filteredCookies.length !== 1 ? 's' : ''} for this site
-          </div>
         </div>
 
-        <div className="space-y-2 max-h-80 overflow-y-auto">
+        <p className="hud-subtext">Found {filteredCookies.length} cookie{filteredCookies.length === 1 ? '' : 's'} for this site</p>
+      </section>
+
+      <section className="hud-section">
+        <div className="hud-stack">
           {filteredCookies.length === 0 ? (
-            <div className="text-center text-gray-500 py-8">
-              No cookies found for this site
+            <div className="hud-empty">
+              <p>No cookies found for this site.</p>
             </div>
           ) : (
             filteredCookies.map((cookie, index) => (
-              <div key={index} className="bg-gray-800 border border-gray-700 rounded-lg p-3 shadow-sm">
-                <div className="flex justify-between items-start">
-                  <div className="flex-1">
-                    <div className="font-medium text-sm text-cyan-400">{cookie.name}</div>
-                    <div className="text-xs text-gray-400 mt-1">
-                      Domain: {cookie.domain} | Path: {cookie.path}
-                    </div>
-                    <div className="text-xs text-gray-500 mt-1">
-                      {cookie.secure && <span className="bg-green-600 text-white px-1 rounded text-xs mr-1">Secure</span>}
-                      {cookie.httpOnly && <span className="bg-blue-600 text-white px-1 rounded text-xs mr-1">HttpOnly</span>}
-                      {cookie.expirationDate && <span className="text-gray-400">Expires: {new Date(cookie.expirationDate * 1000).toLocaleDateString()}</span>}
-                    </div>
-                    <div className="text-xs text-gray-400 mt-1 truncate">
-                      Value: {cookie.value.length > 50 ? cookie.value.substring(0, 50) + '...' : cookie.value}
-                    </div>
+              <article key={index} className="hud-list-card">
+                <div className="hud-list-card__header">
+                  <div>
+                    <h3 className="hud-list-card__title">{cookie.name}</h3>
+                    <p className="hud-list-card__meta">Domain: {cookie.domain} • Path: {cookie.path}</p>
                   </div>
                   <button
+                    type="button"
                     onClick={() => deleteCookie(cookie)}
-                    className="ml-2 px-2 py-1 bg-red-600 text-white text-xs rounded hover:bg-red-500 transition-colors"
+                    className="hud-btn"
+                    data-variant="danger"
+                    data-size="xs"
                   >
                     Delete
                   </button>
                 </div>
-              </div>
+
+                <div className="hud-pill-row">
+                  {cookie.secure && <span className="hud-pill" data-variant="success">Secure</span>}
+                  {cookie.httpOnly && <span className="hud-pill" data-variant="info">HttpOnly</span>}
+                  {cookie.expirationDate && (
+                    <span className="hud-pill" data-variant="neutral">
+                      Expires: {new Date(cookie.expirationDate * 1000).toLocaleDateString()}
+                    </span>
+                  )}
+                </div>
+
+                <p className="hud-subtext hud-subtext--mono">
+                  Value: {cookie.value.length > 64 ? `${cookie.value.substring(0, 64)}…` : cookie.value}
+                </p>
+              </article>
             ))
           )}
         </div>
-      </div>
+      </section>
     </div>
   );
 };

--- a/src/components/EmailListManager.tsx
+++ b/src/components/EmailListManager.tsx
@@ -168,143 +168,198 @@ const EmailListManager: React.FC = () => {
   const currentEntries = currentGroup?.entries || [];
 
   return (
-    <div className="min-h-full bg-gray-900 text-gray-100">
-      {/* Header */}
-      <div className="bg-gray-800 border-b border-gray-700 p-4">
-        <h2 className="text-lg font-semibold" style={{color: '#15FFFF'}}>Email List Manager</h2>
-        <p className="text-sm text-gray-400">One-click dropdown with editable email entries</p>
-      </div>
-
-      <div className="p-4 space-y-4">
-        {/* One-Click Dropdown */}
-        <div className="relative">
-          <select
-            value={activeGroup}
-            onChange={(e) => setActiveGroup(e.target.value)}
-            className="w-full px-4 py-3 bg-gray-800 border-2 border-gray-600 text-gray-100 rounded-lg focus:outline-none focus:border-cyan-400 text-lg font-medium"
-            style={{borderColor: activeGroup ? '#15FFFF' : undefined, color: activeGroup ? '#15FFFF' : undefined}}
-          >
-            <option value="">📧 Select Email Group...</option>
-            {emailGroups.map(group => (
-              <option key={group.id} value={group.id}>{group.name}</option>
-            ))}
-          </select>
-          
-          <button
-            onClick={() => setShowNewGroup(true)}
-            className="absolute right-2 top-2 px-3 py-2 text-sm rounded-md transition-colors"
-            style={{backgroundColor: '#15FFFF', color: '#111827'}}
-          >
-            + New
-          </button>
+    <div className="hud-scroll space-y-4">
+      <section className="hud-section">
+        <div className="hud-section-header">
+          <div>
+            <h2 className="hud-section-title">Email list manager</h2>
+            <p className="hud-section-subtitle">One-click dropdown with editable email entries</p>
+          </div>
+          <span className="hud-chip">
+            <span className="hud-chip__dot" />
+            {emailGroups.length > 0 ? `${emailGroups.length} groups` : 'No groups yet'}
+          </span>
         </div>
 
-        {/* New Group Creation */}
-        {showNewGroup && (
-          <div className="flex items-center space-x-2 p-4 bg-gray-800 rounded-lg border-2" style={{borderColor: '#15FFFF'}}>
-            <input
-              type="text"
-              placeholder="Group name..."
-              value={newGroupName}
-              onChange={(e) => setNewGroupName(e.target.value)}
-              className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 text-gray-100 rounded focus:outline-none focus:border-cyan-400"
-              onKeyPress={(e) => e.key === 'Enter' && createNewGroup()}
-            />
+        <div className="hud-field-vertical">
+          <span className="hud-label">Active group</span>
+          <div className="hud-field-row">
+            <div className={`hud-select-wrapper${activeGroup ? '' : ' hud-select-wrapper--empty'}`}>
+              <select
+                id="email-group-select"
+                value={activeGroup}
+                onChange={(e) => setActiveGroup(e.target.value)}
+                className="hud-select"
+              >
+                <option value="">📧 Select email group…</option>
+                {emailGroups.map(group => (
+                  <option key={group.id} value={group.id}>{group.name}</option>
+                ))}
+              </select>
+            </div>
             <button
-              onClick={createNewGroup}
-              className="px-4 py-2 rounded font-medium transition-colors"
-              style={{backgroundColor: '#15FFFF', color: '#111827'}}
+              type="button"
+              onClick={() => setShowNewGroup(true)}
+              className="hud-btn"
+              data-variant="accent"
+              data-size="sm"
             >
-              Create
-            </button>
-            <button
-              onClick={() => {
-                setShowNewGroup(false);
-                setNewGroupName('');
-              }}
-              className="px-4 py-2 bg-gray-600 text-gray-300 rounded hover:bg-gray-500 transition-colors"
-            >
-              Cancel
+              + New
             </button>
           </div>
-        )}
+        </div>
+      </section>
 
-        {/* Email Entries with Copy Buttons */}
-        {activeGroup && (
-          <div className="space-y-3">
-            {/* Quick Actions */}
-            <div className="flex items-center justify-between p-3 bg-gray-800 rounded-lg border border-gray-700">
-              <h3 className="text-lg font-medium" style={{color: '#15FFFF'}}>
-                {emailGroups.find(g => g.id === activeGroup)?.name}
-              </h3>
-              <div className="flex space-x-2">
+      {showNewGroup && (
+        <section className="hud-section hud-section--inline">
+          <div className="hud-field-vertical">
+            <span className="hud-label">Create group</span>
+            <div className="hud-field-row">
+              <input
+                type="text"
+                placeholder="Group name…"
+                value={newGroupName}
+                onChange={(e) => setNewGroupName(e.target.value)}
+                className="hud-input"
+                onKeyDown={(e) => e.key === 'Enter' && createNewGroup()}
+              />
+              <div className="hud-toolbar">
                 <button
-                  onClick={addEmailEntry}
-                  className="px-3 py-1 text-sm rounded font-medium transition-colors"
-                  style={{backgroundColor: '#15FFFF', color: '#111827'}}
+                  type="button"
+                  onClick={createNewGroup}
+                  className="hud-btn"
+                  data-variant="accent"
+                  data-size="sm"
                 >
-                  + Add Entry
+                  Create
                 </button>
                 <button
-                  onClick={exportGroupAsText}
-                  className="px-3 py-1 bg-green-600 text-white text-sm rounded hover:bg-green-500 transition-colors font-medium"
-                >
-                  Copy All Emails
-                </button>
-                <button
+                  type="button"
                   onClick={() => {
-                    const labels = currentEntries
-                      .filter(e => e.label)
-                      .map(e => e.label)
-                      .join(', ');
-                    copyToClipboard(labels);
+                    setShowNewGroup(false);
+                    setNewGroupName('');
                   }}
-                  className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-500 transition-colors font-medium"
+                  className="hud-btn"
+                  data-variant="ghost"
+                  data-size="sm"
                 >
-                  Copy All Labels
+                  Cancel
                 </button>
               </div>
             </div>
+          </div>
+        </section>
+      )}
 
-            {/* Editable Email Rows */}
-            {currentEntries.map((entry) => (
-              <div key={entry.id} className="flex items-center space-x-2 p-3 bg-gray-800 rounded-lg border border-gray-700 hover:border-gray-600 transition-colors">
-                <input
-                  type="text"
-                  placeholder="Label (m1, m2...)"
-                  value={entry.label}
-                  onChange={(e) => updateEmailEntry(entry.id, 'label', e.target.value)}
-                  className="w-32 px-3 py-2 bg-gray-700 border border-gray-600 text-gray-100 rounded focus:outline-none focus:border-cyan-400"
-                />
-                <input
-                  type="email"
-                  placeholder="email@example.com"
-                  value={entry.email}
-                  onChange={(e) => updateEmailEntry(entry.id, 'email', e.target.value)}
-                  className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 text-gray-100 rounded focus:outline-none focus:border-cyan-400"
-                />
-                <button
-                  onClick={() => copyToClipboard(entry.email)}
-                  className="px-3 py-2 bg-green-600 text-white text-sm rounded hover:bg-green-500 transition-colors font-medium"
-                  disabled={!entry.email}
-                >
-                  📋 Copy
-                </button>
-                <button
-                  onClick={() => deleteEmailEntry(entry.id)}
-                  className="px-3 py-2 bg-red-600 text-white text-sm rounded hover:bg-red-500 transition-colors font-medium"
-                >
-                  🗑️ Delete
-                </button>
+      {activeGroup && (
+        <>
+          <section className="hud-section">
+            <div className="hud-section-header">
+              <div>
+                <h3 className="hud-section-title">{emailGroups.find(g => g.id === activeGroup)?.name || 'Selected group'}</h3>
+                <p className="hud-section-subtitle">Manage addresses, copy blocks, and import text lists</p>
               </div>
-            ))}
+              <span className="hud-chip">
+                <span className="hud-chip__dot" />
+                {currentEntries.length} entr{currentEntries.length === 1 ? 'y' : 'ies'}
+              </span>
+            </div>
 
-            {/* Import from Text */}
-            <div className="p-3 bg-gray-800 rounded-lg border border-gray-700">
-              <h4 className="text-sm font-medium text-gray-300 mb-2">Import from Text</h4>
+            <div className="hud-toolbar">
+              <button
+                type="button"
+                onClick={addEmailEntry}
+                className="hud-btn"
+                data-variant="accent"
+                data-size="sm"
+              >
+                + Add entry
+              </button>
+              <button
+                type="button"
+                onClick={exportGroupAsText}
+                className="hud-btn"
+                data-variant="ghost"
+                data-size="sm"
+              >
+                📋 Copy emails
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const labels = currentEntries
+                    .filter(e => e.label)
+                    .map(e => e.label)
+                    .join(', ');
+                  copyToClipboard(labels);
+                }}
+                className="hud-btn"
+                data-variant="ghost"
+                data-size="sm"
+              >
+                🏷️ Copy labels
+              </button>
+            </div>
+
+            <div className="hud-stack">
+              {currentEntries.length === 0 ? (
+                <div className="hud-empty">
+                  <p>No saved addresses yet. Add an entry or import from text.</p>
+                </div>
+              ) : (
+                currentEntries.map((entry) => (
+                  <div key={entry.id} className="hud-item">
+                    <div className="hud-item__col hud-item__col--compact">
+                      <span className="hud-label" data-variant="muted">Label</span>
+                      <input
+                        type="text"
+                        placeholder="Label (m1, m2…)"
+                        value={entry.label}
+                        onChange={(e) => updateEmailEntry(entry.id, 'label', e.target.value)}
+                        className="hud-input hud-input--compact"
+                      />
+                    </div>
+                    <div className="hud-item__col">
+                      <span className="hud-label" data-variant="muted">Email</span>
+                      <input
+                        type="email"
+                        placeholder="email@example.com"
+                        value={entry.email}
+                        onChange={(e) => updateEmailEntry(entry.id, 'email', e.target.value)}
+                        className="hud-input"
+                      />
+                    </div>
+                    <div className="hud-item__actions">
+                      <button
+                        type="button"
+                        onClick={() => copyToClipboard(entry.email)}
+                        className="hud-btn"
+                        data-variant="ghost"
+                        data-size="xs"
+                        disabled={!entry.email}
+                      >
+                        📋 Copy
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => deleteEmailEntry(entry.id)}
+                        className="hud-btn"
+                        data-variant="danger"
+                        data-size="xs"
+                      >
+                        🗑️ Delete
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="hud-subsection">
+              <h4 className="hud-section-subtitle">Import from text</h4>
               <textarea
                 placeholder="Paste email list here (format: label: email@example.com)"
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 text-gray-100 rounded focus:outline-none focus:border-cyan-400 text-sm"
+                className="hud-textarea"
                 rows={3}
                 onPaste={(e) => {
                   setTimeout(() => {
@@ -316,23 +371,23 @@ const EmailListManager: React.FC = () => {
                   }, 100);
                 }}
               />
-              <p className="text-xs text-gray-500 mt-1">
-                Format: "m1: user@domain.com" (one per line)
-              </p>
+              <p className="hud-subtext">Format: “m1: user@domain.com” (one per line)</p>
             </div>
 
-            {/* Delete Group */}
-            <div className="flex justify-end">
+            <div className="hud-toolbar hud-toolbar--right">
               <button
+                type="button"
                 onClick={() => deleteGroup(activeGroup)}
-                className="px-4 py-2 bg-red-600 text-white text-sm rounded hover:bg-red-500 transition-colors font-medium"
+                className="hud-btn"
+                data-variant="danger"
+                data-size="sm"
               >
-                🗑️ Delete Group
+                🗑️ Delete group
               </button>
             </div>
-          </div>
-        )}
-      </div>
+          </section>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/SiteClearanceManager.tsx
+++ b/src/components/SiteClearanceManager.tsx
@@ -43,9 +43,9 @@ const SiteClearanceManager: React.FC = () => {
     }
   };
 
-  const saveSettings = async () => {
+  const saveSettings = async (value: boolean) => {
     try {
-      await chrome.storage.local.set({ autoReload });
+      await chrome.storage.local.set({ autoReload: value });
     } catch (error) {
       console.error('Error saving settings:', error);
     }
@@ -166,101 +166,94 @@ const SiteClearanceManager: React.FC = () => {
   };
 
   return (
-    <div className="min-h-full bg-gray-900 text-gray-100">
-      {/* Header */}
-      <div className="bg-gray-800 border-b border-gray-700 p-4">
-        <h2 className="text-lg font-semibold mb-2" style={{color: '#15FFFF'}}>Site Clearance Manager</h2>
-        <p className="text-sm text-gray-400">Press Alt+C to clear all site data instantly</p>
-      </div>
-      <div className="text-sm text-gray-400">
-        Current Site: <span className="text-cyan-400 font-mono">{currentSite || 'Unknown'}</span>
-      </div>
-
-      {/* Main Actions */}
-      <div className="p-4 space-y-4">
-        {/* Quick Clear Button */}
-        <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-          <h3 className="text-md font-medium text-cyan-400 mb-3">Quick Clear (Alt+C)</h3>
-          <div className="space-y-3">
-            <div className="text-center p-4 bg-gray-800 rounded-lg border-2" style={{borderColor: '#15FFFF'}}>
-              <div className="text-2xl mb-2">⌨️</div>
-              <div className="text-lg font-bold" style={{color: '#15FFFF'}}>Alt + C</div>
-              <div className="text-sm text-gray-400 mt-1">Quick Site Clear Hotkey</div>
-            </div>
-            
-            <button
-              onClick={clearSiteData}
-              disabled={isClearing}
-              className={`w-full py-3 px-4 rounded font-medium transition-colors ${
-                isClearing
-                  ? 'bg-gray-600 text-gray-400 cursor-not-allowed'
-                  : 'bg-red-600 text-white hover:bg-red-500'
-              }`}
-            >
-              {isClearing ? '🔄 Clearing...' : '🗑️ Manual Clear Site Data'}
-            </button>
+    <div className="hud-scroll space-y-4">
+      <section className="hud-section">
+        <div className="hud-section-header">
+          <div>
+            <h2 className="hud-section-title">Site clearance manager</h2>
+            <p className="hud-section-subtitle">Press Alt+C to clear all site data instantly</p>
           </div>
-          <p className="text-xs text-gray-500 mt-2">
-            Clears cookies, localStorage, sessionStorage, indexedDB, webSQL, and cache for this site only
-          </p>
+          <span className="hud-chip">
+            <span className="hud-chip__dot" />
+            {currentSite ? currentSite : 'Unknown site'}
+          </span>
         </div>
+      </section>
 
-        {/* Site-Specific Cookie Export */}
-        <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-          <h3 className="text-md font-medium text-cyan-400 mb-3">Site Cookie Export</h3>
-          <button
-            onClick={exportSiteCookies}
-            disabled={!currentSite}
-            className="w-full py-2 px-4 bg-cyan-400 text-gray-900 rounded font-medium hover:bg-cyan-300 transition-colors disabled:bg-gray-600 disabled:text-gray-400"
-          >
-            Export Site Cookies
-          </button>
-          <p className="text-xs text-gray-500 mt-2">
-            Export cookies for the current site as JSON file
-          </p>
-        </div>
-
-        {/* Settings */}
-        <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-          <h3 className="text-md font-medium text-cyan-400 mb-3">Settings</h3>
-          <label className="flex items-center space-x-3">
-            <input
-              type="checkbox"
-              checked={autoReload}
-              onChange={(e) => {
-                setAutoReload(e.target.checked);
-                saveSettings();
-              }}
-              className="w-4 h-4 text-cyan-400 bg-gray-700 border-gray-600 rounded focus:ring-cyan-400"
-            />
-            <span className="text-sm text-gray-300">Auto-reload page after clearing</span>
-          </label>
-        </div>
-
-        {/* Last Clearance Stats */}
-        {lastClearance && (
-          <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-            <h3 className="text-md font-medium text-cyan-400 mb-3">Last Clearance</h3>
-            <div className="grid grid-cols-2 gap-2 text-sm">
-              <div className="text-gray-400">Cookies cleared:</div>
-              <div className="text-cyan-400 font-mono">{lastClearance.cookies}</div>
-              <div className="text-gray-400">Storage cleared:</div>
-              <div className="text-cyan-400">✓ All types</div>
-            </div>
-          </div>
-        )}
-
-        {/* Keyboard Shortcut Info */}
-        <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
-          <h3 className="text-md font-medium text-cyan-400 mb-2">Keyboard Shortcut</h3>
-          <div className="flex items-center space-x-2">
-            <kbd className="px-2 py-1 bg-gray-700 border border-gray-600 rounded text-xs font-mono">Alt</kbd>
-            <span className="text-gray-400">+</span>
-            <kbd className="px-2 py-1 bg-gray-700 border border-gray-600 rounded text-xs font-mono">C</kbd>
-            <span className="text-sm text-gray-400 ml-2">Clear current site data</span>
+      <section className="hud-section">
+        <h3 className="hud-section-title">Quick clear</h3>
+        <div className="hud-hotkey">
+          <span className="hud-hotkey__icon" aria-hidden="true">⌨️</span>
+          <div>
+            <div className="hud-hotkey__title">Alt + C</div>
+            <p className="hud-subtext">Instantly purge cookies, storage, indexedDB, webSQL, and cache for this site.</p>
           </div>
         </div>
-      </div>
+        <button
+          type="button"
+          onClick={clearSiteData}
+          disabled={isClearing}
+          className="hud-btn"
+          data-variant="danger"
+          data-block="true"
+        >
+          {isClearing ? '🔄 Clearing…' : '🗑️ Clear site data now'}
+        </button>
+      </section>
+
+      <section className="hud-section">
+        <h3 className="hud-section-title">Site cookie export</h3>
+        <p className="hud-subtext">Export cookies for the current site as a JSON file.</p>
+        <button
+          type="button"
+          onClick={exportSiteCookies}
+          disabled={!currentSite}
+          className="hud-btn"
+          data-variant="accent"
+          data-block="true"
+        >
+          Export site cookies
+        </button>
+      </section>
+
+      <section className="hud-section hud-section--inline">
+        <h3 className="hud-section-title">Settings</h3>
+        <label className="hud-toggle">
+          <input
+            type="checkbox"
+            checked={autoReload}
+            onChange={(e) => {
+              const value = e.target.checked;
+              setAutoReload(value);
+              saveSettings(value);
+            }}
+            className="hud-toggle__input"
+          />
+          <span className="hud-toggle__label">Auto-reload page after clearing</span>
+        </label>
+      </section>
+
+      {lastClearance && (
+        <section className="hud-section hud-section--inline">
+          <h3 className="hud-section-title">Last clearance</h3>
+          <div className="hud-stat-grid">
+            <span className="hud-subtext">Cookies cleared</span>
+            <span className="hud-subtext hud-subtext--mono">{lastClearance.cookies}</span>
+            <span className="hud-subtext">Storage cleared</span>
+            <span className="hud-subtext">✓ Local, session, indexedDB, webSQL</span>
+          </div>
+        </section>
+      )}
+
+      <section className="hud-section hud-section--inline">
+        <h3 className="hud-section-title">Keyboard shortcut</h3>
+        <div className="hud-keyboard">
+          <kbd>Alt</kbd>
+          <span>+</span>
+          <kbd>C</kbd>
+          <span className="hud-subtext">Clear current site data</span>
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -18,13 +18,12 @@ const TabNavigation: React.FC<TabNavigationProps> = ({ tabs, activeTab, onTabCha
       {tabs.map((tab) => (
         <button
           key={tab.id}
+          type="button"
           onClick={() => onTabChange(tab.id)}
           className={`hud-tab ${activeTab === tab.id ? 'hud-tab-active' : ''}`}
         >
-          <div className="flex items-center justify-center space-x-2">
-            <span className="text-lg">{tab.icon}</span>
-            <span>{tab.label}</span>
-          </div>
+          <span className="hud-tab__icon" aria-hidden="true">{tab.icon}</span>
+          <span className="hud-tab__label">{tab.label}</span>
         </button>
       ))}
     </div>

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -33,20 +33,30 @@ const Popup = () => {
   };
 
   return (
-    <div className="w-full h-full bg-gradient-to-br from-gray-950 via-gray-900 to-gray-800">
-      <div className="hud-card m-2">
-        <div className="border-b border-cyan-300/20 px-4 py-3">
-          <h1 className="text-lg font-bold" style={{ color: '#15FFFF' }}>4ndr0cookie</h1>
-          <p className="text-xs text-gray-400">Red-team Quality of Life</p>
-        </div>
-        
-        <TabNavigation 
-          tabs={tabs} 
-          activeTab={activeTab} 
-          onTabChange={setActiveTab} 
+    <div className="hud-app">
+      <div className="hud-backdrop hud-backdrop--grid" aria-hidden="true" />
+      <div className="hud-backdrop hud-backdrop--pulse" aria-hidden="true" />
+      <div className="hud-backdrop hud-backdrop--accent" aria-hidden="true" />
+
+      <div className="hud-card">
+        <header className="hud-card-header">
+          <div>
+            <h1 className="hud-card-title">4ndr0cookie</h1>
+            <p className="hud-card-subtitle">Red-team quality of life toolkit</p>
+          </div>
+          <span className="hud-chip" data-variant="neutral">
+            <span className="hud-chip__dot" />
+            Operational
+          </span>
+        </header>
+
+        <TabNavigation
+          tabs={tabs}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
         />
-        
-        <div className="p-3">
+
+        <div className="hud-content">
           {renderTabContent()}
         </div>
       </div>

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -2,40 +2,1031 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  color-scheme: dark;
+  --hud-cyan: #15ffff;
+  --hud-cyan-soft: #64f5ff;
+  --hud-bg: #040b12;
+  --hud-panel: rgba(6, 18, 26, 0.85);
+  --hud-panel-alt: rgba(7, 21, 30, 0.7);
+  --hud-text: #e6fbff;
+  font-family: 'Rajdhani', 'Segoe UI', 'Roboto', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  height: 100%;
+}
+
 body {
-    width: 450px;
-    height: 600px;
-    background-color: #0b0f14;
-    color: #e5f7ff;
+  width: 480px;
+  height: 640px;
+  margin: 0;
+  background:
+    radial-gradient(circle at 15% -10%, rgba(21, 255, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 85% 0%, rgba(0, 196, 255, 0.18), transparent 60%),
+    radial-gradient(circle at 50% 115%, rgba(0, 78, 140, 0.35), transparent 70%),
+    var(--hud-bg);
+  color: var(--hud-text);
+  font-family: 'Rajdhani', 'Segoe UI', 'Roboto', sans-serif;
+  letter-spacing: 0.02em;
+  overflow: hidden;
 }
 
-@layer components {
+body, button, input, textarea, select {
+  font-family: 'Rajdhani', 'Segoe UI', 'Roboto', sans-serif;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+.hud-app {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.hud-backdrop {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hud-backdrop--grid {
+  background-image:
+    linear-gradient(transparent calc(100% - 1px), rgba(21, 255, 255, 0.08) 1px),
+    linear-gradient(90deg, transparent calc(100% - 1px), rgba(21, 255, 255, 0.08) 1px);
+  background-size: 58px 58px;
+  opacity: 0.18;
+  mix-blend-mode: screen;
+}
+
+.hud-backdrop--pulse {
+  background:
+    radial-gradient(circle at 15% -10%, rgba(21, 255, 255, 0.38), transparent 55%),
+    radial-gradient(circle at 88% -15%, rgba(0, 170, 255, 0.3), transparent 55%),
+    radial-gradient(circle at 50% 120%, rgba(0, 70, 120, 0.32), transparent 60%);
+  opacity: 0.85;
+}
+
+.hud-backdrop--accent {
+  background:
+    linear-gradient(120deg, rgba(21, 255, 255, 0.12), transparent 45%),
+    linear-gradient(300deg, rgba(0, 150, 255, 0.16), transparent 60%);
+  mix-blend-mode: screen;
+  opacity: 0.9;
+}
+
+.hud-card {
+  position: relative;
+  margin: 1.15rem auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: min(460px, calc(100% - 2.3rem));
+  max-height: calc(100% - 2.3rem);
+  min-height: 0;
+  border-radius: 22px;
+  border: 1px solid rgba(21, 255, 255, 0.35);
+  background: linear-gradient(145deg, rgba(6, 18, 28, 0.95), rgba(4, 12, 20, 0.78));
+  box-shadow: 0 26px 55px rgba(0, 0, 0, 0.62), 0 0 35px rgba(21, 255, 255, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(18px);
+  overflow: hidden;
+  z-index: 1;
+}
+
+.hud-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(21, 255, 255, 0.2), transparent 40%);
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.hud-card::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  pointer-events: none;
+}
+
+.hud-card-header {
+  position: relative;
+  padding: 1.45rem 1.6rem 1.2rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.4rem;
+  border-bottom: 1px solid rgba(21, 255, 255, 0.22);
+  z-index: 2;
+}
+
+.hud-card-header > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hud-card-header::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(21, 255, 255, 0.65), transparent);
+  opacity: 0.75;
+}
+
+.hud-card-title {
+  margin: 0;
+  font-size: 1.45rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--hud-cyan);
+  text-shadow: 0 0 18px rgba(21, 255, 255, 0.75);
+}
+
+.hud-card-subtitle {
+  margin: 0.4rem 0 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(140, 234, 255, 0.65);
+}
+
+.hud-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(21, 255, 255, 0.4);
+  background: rgba(6, 28, 35, 0.7);
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(143, 246, 255, 0.88);
+  box-shadow: 0 0 18px rgba(21, 255, 255, 0.18);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.hud-chip[data-variant="neutral"] {
+  border-color: rgba(111, 220, 255, 0.35);
+  background: rgba(10, 32, 40, 0.65);
+  color: rgba(178, 242, 255, 0.8);
+}
+
+.hud-chip__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--hud-cyan), rgba(21, 255, 255, 0.3));
+  box-shadow: 0 0 12px rgba(21, 255, 255, 0.7);
+}
+
+.hud-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.5rem 1.5rem;
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.hud-tabs {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+  padding: 0.9rem 1.4rem 0.95rem;
+  background: linear-gradient(135deg, rgba(6, 22, 32, 0.85), rgba(3, 12, 18, 0.8));
+  border-bottom: 1px solid rgba(21, 255, 255, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.hud-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.6rem 0.5rem;
+  border-radius: 14px;
+  border: 1px solid rgba(21, 255, 255, 0.35);
+  background: rgba(4, 15, 24, 0.8);
+  color: rgba(147, 237, 255, 0.85);
+  font-size: 0.76rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  box-shadow: 0 12px 25px rgba(3, 10, 18, 0.65);
+}
+
+.hud-tab::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(130deg, rgba(21, 255, 255, 0.25), transparent 55%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.hud-tab:hover {
+  transform: translateY(-2px);
+  border-color: rgba(21, 255, 255, 0.65);
+  box-shadow: 0 14px 32px rgba(21, 255, 255, 0.2);
+}
+
+.hud-tab:hover::before {
+  opacity: 0.6;
+}
+
+.hud-tab-active {
+  color: #03292b;
+  border-color: rgba(21, 255, 255, 0.95);
+  background: linear-gradient(135deg, rgba(21, 255, 255, 0.95), rgba(10, 160, 255, 0.75));
+  box-shadow: 0 18px 34px rgba(21, 255, 255, 0.28);
+}
+
+.hud-tab-active::before {
+  opacity: 0.8;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), transparent 65%);
+}
+
+.hud-tab__icon {
+  font-size: 1.05rem;
+  filter: drop-shadow(0 0 8px rgba(21, 255, 255, 0.6));
+}
+
+.hud-tab__label {
+  position: relative;
+  z-index: 1;
+}
+
+.hud-scroll {
+  height: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.45rem;
+  padding-bottom: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  overscroll-behavior: contain;
+}
+
+.hud-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.hud-scroll::-webkit-scrollbar-track {
+  background: rgba(5, 20, 28, 0.65);
+  border-radius: 999px;
+}
+
+.hud-scroll::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, rgba(21, 255, 255, 0.85), rgba(21, 255, 255, 0.25));
+  border-radius: 999px;
+  box-shadow: 0 0 12px rgba(21, 255, 255, 0.35);
+}
+
+.hud-scroll {
+  scrollbar-color: rgba(21, 255, 255, 0.45) rgba(5, 20, 28, 0.65);
+}
+
+.hud-section {
+  position: relative;
+  padding: 1.35rem;
+  border-radius: 18px;
+  border: 1px solid rgba(21, 255, 255, 0.26);
+  background: linear-gradient(140deg, rgba(7, 20, 30, 0.92), rgba(5, 16, 24, 0.72));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 22px 38px rgba(2, 10, 18, 0.58);
+  overflow: hidden;
+}
+
+.hud-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(21, 255, 255, 0.16), transparent 55%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.hud-section--inline {
+  background: linear-gradient(140deg, rgba(6, 18, 28, 0.86), rgba(4, 14, 22, 0.68));
+  border-color: rgba(21, 255, 255, 0.2);
+}
+
+.hud-section-header {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+  row-gap: 0.9rem;
+  margin-bottom: 1rem;
+  z-index: 1;
+}
+
+.hud-section-header > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hud-section-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(126, 246, 255, 0.95);
+}
+
+.hud-section-subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(146, 235, 255, 0.65);
+}
+
+.hud-field-vertical {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  z-index: 1;
+}
+
+.hud-field-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: stretch;
+  width: 100%;
+}
+
+.hud-field-row > * {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.hud-field-row > :first-child {
+  flex: 1 1 220px;
+}
+
+.hud-field-row > [data-block="true"] {
+  flex: 1 1 240px;
+  width: auto;
+}
+
+.hud-field-row > .hud-toolbar {
+  margin-left: auto;
+  justify-content: flex-end;
+}
+
+.hud-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(146, 235, 255, 0.7);
+}
+
+.hud-label[data-variant="muted"] {
+  color: rgba(146, 235, 255, 0.5);
+}
+
+.hud-select-wrapper {
+  position: relative;
+  flex: 1;
+  border-radius: 14px;
+  border: 1px solid rgba(21, 255, 255, 0.28);
+  background: rgba(6, 18, 26, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  min-width: 0;
+}
+
+.hud-select-wrapper--empty {
+  border-color: rgba(21, 255, 255, 0.18);
+  color: rgba(146, 235, 255, 0.6);
+}
+
+.hud-select {
+  appearance: none;
+  width: 100%;
+  padding: 0.7rem 1rem;
+  border: none;
+  background: transparent;
+  color: rgba(158, 246, 255, 0.9);
+  font-size: 0.88rem;
+  letter-spacing: 0.04em;
+}
+
+.hud-select:focus {
+  outline: none;
+}
+
+.hud-select-wrapper::after {
+  content: '▾';
+  position: absolute;
+  right: 0.85rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: rgba(146, 235, 255, 0.7);
+  font-size: 0.85rem;
+}
+
+.hud-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 14px;
+  border: 1px solid rgba(21, 255, 255, 0.4);
+  background: rgba(7, 20, 30, 0.75);
+  color: rgba(160, 246, 255, 0.9);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  box-shadow: 0 14px 26px rgba(2, 12, 20, 0.55);
+}
+
+.hud-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(21, 255, 255, 0.22), transparent 60%);
+  opacity: 0.35;
+  transition: opacity 0.2s ease;
+}
+
+.hud-btn:hover {
+  transform: translateY(-2px);
+  border-color: rgba(21, 255, 255, 0.62);
+  box-shadow: 0 18px 35px rgba(21, 255, 255, 0.22);
+}
+
+.hud-btn:hover::before {
+  opacity: 0.7;
+}
+
+.hud-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+  box-shadow: none;
+}
+
+.hud-btn[data-variant="accent"] {
+  background: linear-gradient(135deg, rgba(21, 255, 255, 0.88), rgba(10, 160, 255, 0.62));
+  color: #021d21;
+  border-color: rgba(21, 255, 255, 0.95);
+  text-shadow: none;
+}
+
+.hud-btn[data-variant="ghost"] {
+  background: rgba(6, 20, 30, 0.65);
+  border-color: rgba(21, 255, 255, 0.25);
+  color: rgba(165, 242, 255, 0.88);
+}
+
+.hud-btn[data-variant="success"] {
+  background: linear-gradient(135deg, rgba(23, 255, 190, 0.88), rgba(8, 140, 118, 0.7));
+  color: #022321;
+  border-color: rgba(21, 255, 200, 0.6);
+}
+
+.hud-btn[data-variant="danger"] {
+  background: linear-gradient(135deg, rgba(255, 84, 120, 0.85), rgba(110, 24, 38, 0.72));
+  color: #fff;
+  border-color: rgba(255, 84, 120, 0.6);
+  box-shadow: 0 12px 28px rgba(255, 78, 120, 0.25);
+}
+
+.hud-btn[data-variant="danger"]:disabled {
+  background: linear-gradient(135deg, rgba(120, 60, 70, 0.6), rgba(80, 30, 36, 0.6));
+}
+
+.hud-btn[data-size="sm"] {
+  padding: 0.5rem 0.8rem;
+  font-size: 0.72rem;
+}
+
+.hud-btn[data-size="xs"] {
+  padding: 0.42rem 0.65rem;
+  font-size: 0.68rem;
+}
+
+.hud-btn[data-block="true"] {
+  width: 100%;
+}
+
+.hud-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.hud-toolbar--right {
+  justify-content: flex-end;
+}
+
+.hud-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.hud-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(130px, 170px) minmax(0, 1fr) auto;
+  gap: 0.8rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(21, 255, 255, 0.24);
+  background: linear-gradient(140deg, rgba(7, 20, 30, 0.9), rgba(5, 16, 24, 0.72));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 18px 30px rgba(2, 10, 18, 0.6);
+}
+
+.hud-item::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(130deg, rgba(21, 255, 255, 0.18), transparent 55%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.hud-item__col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.hud-item__col--compact {
+  max-width: 180px;
+}
+
+.hud-item__actions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+@media (max-width: 520px) {
   .hud-card {
-    position: relative;
-    border: 1px solid rgba(21, 255, 255, 0.25);
-    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.4), 0 0 18px rgba(21,255,255,0.08);
-    background: linear-gradient(180deg, rgba(10,18,24,0.75), rgba(10,18,24,0.55));
-    @apply rounded-lg;
+    width: calc(100% - 2.3rem);
   }
 
-  .hud-btn {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.35rem 0.7rem;
-    border-radius: 0.375rem;
-    border: 1px solid rgba(21,255,255,0.4);
-    color: #bffcff;
-    background: rgba(8,20,24,0.55);
-    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.35), 0 0 12px rgba(21,255,255,0.15);
-    transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+  .hud-field-row > :first-child {
+    flex-basis: 100%;
   }
-  .hud-btn:hover { transform: translateY(-1px); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.35), 0 0 18px rgba(21,255,255,0.25); background: rgba(12,28,34,0.6); }
-  .hud-btn::after { content: ""; position: absolute; right: 8px; top: -4px; width: 26px; height: 8px; background: linear-gradient(90deg, rgba(21,255,255,0), rgba(21,255,255,0.65)); clip-path: polygon(0 0, 100% 0, 85% 100%, 0% 100%); opacity: 0.8; pointer-events: none; }
 
-  .hud-tabs { @apply flex; border-bottom: 1px solid rgba(21,255,255,0.2); background: rgba(10,18,24,0.6); }
-  .hud-tab { @apply flex-1 px-3 py-2 text-xs font-medium transition-colors; color: #bfefff; }
-  .hud-tab:hover { background: rgba(12,28,34,0.55); color: #15FFFF; }
-  .hud-tab-active { background: #15FFFF; color: #062427; border-bottom: 2px solid #15FFFF; }
+  .hud-item {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.75rem;
+  }
+
+  .hud-item__col--compact,
+  .hud-item__col {
+    max-width: none;
+  }
+
+  .hud-item__actions {
+    justify-content: flex-start;
+  }
 }
+
+.hud-input {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(21, 255, 255, 0.22);
+  background: rgba(5, 16, 24, 0.92);
+  color: rgba(214, 251, 255, 0.92);
+  font-size: 0.84rem;
+  letter-spacing: 0.03em;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+  min-width: 0;
+}
+
+.hud-input:hover {
+  border-color: rgba(21, 255, 255, 0.36);
+}
+
+.hud-input:focus {
+  outline: none;
+  border-color: rgba(21, 255, 255, 0.7);
+  box-shadow: 0 0 12px rgba(21, 255, 255, 0.35);
+}
+
+.hud-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.hud-input--compact {
+  max-width: 150px;
+}
+
+.hud-input-wrapper {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.hud-input-wrapper .hud-input {
+  padding-right: 2.6rem;
+}
+
+.hud-input-toggle {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  color: rgba(146, 235, 255, 0.65);
+  cursor: pointer;
+  font-size: 1rem;
+  transition: color 0.18s ease;
+}
+
+.hud-input-toggle:hover {
+  color: var(--hud-cyan);
+}
+
+.hud-textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(21, 255, 255, 0.22);
+  background: rgba(5, 16, 24, 0.9);
+  color: rgba(210, 248, 255, 0.9);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.hud-textarea:focus {
+  outline: none;
+  border-color: rgba(21, 255, 255, 0.68);
+  box-shadow: 0 0 12px rgba(21, 255, 255, 0.32);
+}
+
+.hud-subsection {
+  margin-top: 1.2rem;
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px dashed rgba(21, 255, 255, 0.28);
+  background: rgba(5, 16, 24, 0.65);
+  position: relative;
+  z-index: 1;
+}
+
+.hud-subtext {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(150, 232, 255, 0.62);
+}
+
+.hud-subtext--mono {
+  font-family: 'Share Tech Mono', 'Roboto Mono', monospace;
+  letter-spacing: 0.06em;
+  color: rgba(166, 242, 255, 0.82);
+}
+
+.hud-empty {
+  text-align: center;
+  padding: 2.2rem 1rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(21, 255, 255, 0.28);
+  color: rgba(150, 232, 255, 0.6);
+  background: rgba(5, 16, 24, 0.62);
+}
+
+.hud-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0.7rem 0 0.5rem;
+}
+
+.hud-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: 1px solid rgba(21, 255, 255, 0.28);
+  background: rgba(6, 18, 26, 0.8);
+  color: rgba(158, 242, 255, 0.82);
+}
+
+.hud-pill[data-variant="success"] {
+  border-color: rgba(40, 255, 180, 0.5);
+  background: rgba(16, 120, 96, 0.65);
+  color: rgba(194, 255, 238, 0.85);
+}
+
+.hud-pill[data-variant="info"] {
+  border-color: rgba(60, 160, 255, 0.45);
+  background: rgba(12, 52, 92, 0.65);
+  color: rgba(200, 232, 255, 0.8);
+}
+
+.hud-pill[data-variant="neutral"] {
+  border-color: rgba(140, 180, 210, 0.4);
+  background: rgba(8, 28, 38, 0.6);
+  color: rgba(184, 224, 240, 0.78);
+}
+
+.hud-list-card {
+  position: relative;
+  padding: 1.05rem 1.1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(21, 255, 255, 0.22);
+  background: linear-gradient(140deg, rgba(6, 18, 28, 0.92), rgba(4, 14, 22, 0.7));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 18px 32px rgba(2, 10, 18, 0.56);
+}
+
+.hud-list-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(21, 255, 255, 0.18), transparent 55%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.hud-list-card__header {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  z-index: 1;
+}
+
+.hud-list-card__title {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  color: rgba(132, 243, 255, 0.92);
+}
+
+.hud-list-card__meta {
+  margin: 0.35rem 0 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  color: rgba(150, 232, 255, 0.55);
+}
+
+.hud-loading {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  color: rgba(150, 232, 255, 0.75);
+}
+
+.hud-loading__spinner {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  border: 2px solid rgba(21, 255, 255, 0.15);
+  border-top-color: rgba(21, 255, 255, 0.8);
+  animation: hud-spin 0.9s linear infinite;
+}
+
+@keyframes hud-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.hud-progress {
+  margin-top: 1.2rem;
+  position: relative;
+  z-index: 1;
+}
+
+.hud-progress__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(150, 232, 255, 0.65);
+  margin-bottom: 0.5rem;
+}
+
+.hud-progress__track {
+  width: 100%;
+  height: 0.4rem;
+  border-radius: 999px;
+  background: rgba(5, 16, 24, 0.8);
+  border: 1px solid rgba(21, 255, 255, 0.18);
+  overflow: hidden;
+}
+
+.hud-progress__bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(21, 255, 255, 0.9), rgba(10, 160, 255, 0.65));
+  transition: width 0.25s ease;
+}
+
+.hud-file-input {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(21, 255, 255, 0.24);
+  background: rgba(6, 18, 26, 0.9);
+  color: rgba(180, 240, 255, 0.8);
+  font-size: 0.82rem;
+}
+
+.hud-file-input::file-selector-button {
+  margin-right: 0.9rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 10px;
+  border: none;
+  background: linear-gradient(135deg, rgba(21, 255, 255, 0.85), rgba(10, 150, 255, 0.65));
+  color: #032325;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.hud-file-input:focus-visible {
+  outline: 2px solid rgba(21, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.hud-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem 1rem;
+  align-items: center;
+  margin-top: 0.8rem;
+}
+
+.hud-list {
+  margin: 0.8rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  color: rgba(150, 232, 255, 0.68);
+}
+
+.hud-list li::before {
+  content: '▸';
+  color: var(--hud-cyan);
+  margin-right: 0.45rem;
+  filter: drop-shadow(0 0 8px rgba(21, 255, 255, 0.45));
+}
+
+.hud-hotkey {
+  display: flex;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(21, 255, 255, 0.22);
+  background: rgba(5, 16, 24, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  margin-bottom: 1rem;
+}
+
+.hud-hotkey__icon {
+  font-size: 1.8rem;
+  filter: drop-shadow(0 0 10px rgba(21, 255, 255, 0.6));
+}
+
+.hud-hotkey__title {
+  font-size: 1rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(136, 244, 255, 0.92);
+}
+
+.hud-keyboard {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: rgba(150, 232, 255, 0.68);
+}
+
+.hud-keyboard kbd {
+  padding: 0.3rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(21, 255, 255, 0.32);
+  background: rgba(6, 18, 26, 0.78);
+  box-shadow: 0 0 12px rgba(21, 255, 255, 0.25);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(186, 244, 255, 0.85);
+}
+
+.hud-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hud-toggle__input {
+  appearance: none;
+  width: 46px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid rgba(21, 255, 255, 0.3);
+  background: rgba(6, 18, 26, 0.85);
+  position: relative;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hud-toggle__input::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(21, 255, 255, 0.6);
+  box-shadow: 0 0 8px rgba(21, 255, 255, 0.35);
+  transform: translateY(-50%);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.hud-toggle__input:checked {
+  border-color: rgba(21, 255, 255, 0.75);
+  background: rgba(21, 255, 255, 0.22);
+  box-shadow: 0 0 16px rgba(21, 255, 255, 0.25);
+}
+
+.hud-toggle__input:checked::after {
+  transform: translate(18px, -50%);
+  background: var(--hud-cyan);
+}
+
+.hud-toggle__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(158, 240, 255, 0.7);
+}
+


### PR DESCRIPTION
## Summary
- tighten the popup container sizing and chip/header behavior to prevent overlaps and keep the HUD shell centered.
- refactor shared row and grid utilities so selects, inputs, and buttons resize cleanly without clipping while preserving futuristic styling.
- add responsive safeguards for stacked email entry rows and scroll regions to remove overflow issues across tabs.

## Testing
- npm run build

## Function and line counts
- src/popup/popup.css: 1032 lines, 0 functions

## Coverage
- Coverage delta: N/A (no automated coverage available for this project)

------
https://chatgpt.com/codex/tasks/task_e_68c8e222ae24832ebf1f106255d2438d